### PR TITLE
Restructure findWinner 

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -245,20 +245,19 @@ export function findWinner(poll) {
   /// PREP 1st ROUND
   const roundHistory = [];
   let result;
-  let roundCount = 0;
   const maxRounds = getPoll(poll).length;
 
   do {
-    let lastRoundResults,
-      lastRoundRanking,
-      lastRoundRemainingOptions,
-      summedUpResults,
-      rankingPerUserId,
-      minValue,
-      minKeys,
-      remainingOptions;
+    let lastRoundResults;
+    let lastRoundRanking;
+    let lastRoundRemainingOptions;
+    let summedUpResults;
+    let rankingPerUserId;
+    let minValue;
+    let minKeys;
+    let remainingOptions;
     //Preparation in first round
-    if (roundCount === 0) {
+    if (roundHistory.length === 0) {
       remainingOptions = getPoll(poll);
       rankingPerUserId = collectRankingPerUserId(poll.votes);
       summedUpResults = sumUpResults(remainingOptions, rankingPerUserId);
@@ -266,7 +265,7 @@ export function findWinner(poll) {
     //There wasn't a winner in the last round.
     //So we need to filter out the least favourite options from last round's results
     //And redistribute people's rankings among the options that are still available
-    if (roundCount !== 0) {
+    else {
       // fancy way of destructuring into existing variables (which we rename the original objects keys to match)
       ({
         summedUpResults: lastRoundResults,
@@ -287,7 +286,6 @@ export function findWinner(poll) {
     result = calculateWinner(summedUpResults);
 
     roundHistory.push({
-      roundCount,
       remainingOptions,
       minValue,
       minKeys,
@@ -295,9 +293,7 @@ export function findWinner(poll) {
       summedUpResults,
       result
     });
-
-    roundCount++;
-  } while (result === null && roundCount < maxRounds);
+  } while (result === null && roundHistory.length < maxRounds);
   //check if there's still no winner
   if (result === null) {
     throw new PollException("Couldn't find a winner", roundHistory);

--- a/tests/unit/api.spec.js
+++ b/tests/unit/api.spec.js
@@ -2,7 +2,6 @@ import {
   collectRankingPerUserId,
   sumUpResults,
   calculateWinner,
-  filterSummedUpResults,
   filterRankingPerUserId,
   filterRemainingOptions,
   findWinner
@@ -146,13 +145,6 @@ const summedUpResults = new Map([
   ["hat", 0]
 ]);
 
-const filteredSummedUpResults = new Map([
-  ["rad", 2],
-  ["can", 1],
-  ["eur", 1],
-  ["goc", 1]
-]);
-
 const filteredRankingPerUserId = new Map([
   ["def", ["can", "goc"]],
   ["ghi", ["can", "goc"]],
@@ -205,14 +197,6 @@ describe("calculateWinner", () => {
   });
 });
 
-describe("filterSummedUpResults", () => {
-  it("filters out the tuple with a given value from summedUpResults", () => {
-    expect(filterSummedUpResults(summedUpResults, 0)).toEqual(
-      filteredSummedUpResults
-    );
-  });
-});
-
 describe("filterRankingPerUserId", () => {
   it("filters out certain keys from the remaining options in rankingPerUserId", () => {
     expect(filterRankingPerUserId(rankingPerUserId, ["rad", "eur"])).toEqual(
@@ -238,5 +222,8 @@ describe("findWinner", () => {
 
   it("returns a winnerObject for a given poll", () => {
     expect(findWinner(poll1)).toHaveProperty("result");
+  });
+  it("returns five votes for the given winner", () => {
+    expect(findWinner(poll1).result.votes).toEqual(5);
   });
 });


### PR DESCRIPTION
- sumUpResults runs every round. Starting from the second round it runs with filtered data 
- remove filterSumUpResults (it's not needed anyway) and corresponding unit test
- add Testing for votes count